### PR TITLE
Compiling with `-vet` compiler flag complains about unused import

### DIFF
--- a/enums.odin
+++ b/enums.odin
@@ -1,6 +1,7 @@
 package vma
 
-import c "core:c"
+
+@(require)import c "core:c"
 
 AllocatorCreateFlags :: distinct bit_set[AllocatorCreateFlagBit;u32]
 


### PR DESCRIPTION
Namely, `import c "core:c"` -> `@(require)import c "core:c"`